### PR TITLE
Protect ssh secret key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,9 +76,6 @@ RUN cd $CODE_DIR &&\
 # set github ssh keys #
 #######################
 
-ARG ssh_prv_key
-ARG ssh_pub_key
-
 RUN apt install -y \
     openssh-client git \
     libmysqlclient-dev \
@@ -89,13 +86,7 @@ RUN mkdir -p /root/.ssh && \
     chmod 0700 /root/.ssh
 RUN ssh-keyscan github.com > /root/.ssh/known_hosts
 
-# Add the keys and set permissions
-RUN echo "$ssh_prv_key" > /root/.ssh/id_ed25519 && \
-    echo "$ssh_pub_key" > /root/.ssh/id_ed25519.pub && \
-    chmod 600 /root/.ssh/id_ed25519 && \
-    chmod 600 /root/.ssh/id_ed25519.pub
-
-RUN cd $CODE_DIR &&\
+RUN --mount=type=ssh cd $CODE_DIR &&\
     git clone git@github.com:event-driven-robotics/EDOPT.git &&\
     mv EDOPT object-track-6dof
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Build the docker using:
 
 ```
 cd EDOPT
-docker build -t sixdof:latest --ssh default --build-arg ssh_pub_key="$(cat ~/.ssh/id_rsa.pub)" --build-arg ssh_prv_key="$(cat ~/.ssh/id_rsa)" - < Dockerfile
+docker build -t sixdof:latest --ssh default .
 ```
 Make and enter the container using:
 


### PR DESCRIPTION
## Modification
- Add `--mount=type=ssh` to use host's ssh agent in docker image safely
- Prevent ssh secret key from being copied in docker image