### PR TITLE
Cleanup `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,8 @@ RUN mkdir -p /root/.ssh && \
 RUN ssh-keyscan github.com > /root/.ssh/known_hosts
 
 ARG GIT_BRANCH=main
-RUN --mount=type=ssh cd $CODE_DIR &&\
-    git clone git@github.com:event-driven-robotics/EDOPT.git &&\
+RUN cd $CODE_DIR &&\
+    git clone https://github.com/event-driven-robotics/EDOPT.git &&\
     cd EDOPT &&\
     git checkout $GIT_BRANCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,22 @@ RUN apt install -y \
     libglm-dev \
     libeigen3-dev
 
+# Suggested dependencies for YARP
+RUN apt update && apt install -y \
+    qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev \
+    qml-module-qtquick2 qml-module-qtquick-window2 \
+    qml-module-qtmultimedia qml-module-qtquick-dialogs \
+    qml-module-qtquick-controls qml-module-qt-labs-folderlistmodel \
+    qml-module-qt-labs-settings \
+    libqcustomplot-dev \
+    libgraphviz-dev \
+    libjpeg-dev \
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-libav
+
 RUN echo "deb [arch=amd64 trusted=yes] https://apt.prophesee.ai/dists/public/b4b3528d/ubuntu focal sdk" >> /etc/apt/sources.list &&\
     apt update
 
@@ -34,9 +50,18 @@ RUN apt install -y \
     metavision-sdk
 
 #my favourites
-RUN apt install -y \
+RUN apt update && apt install -y \
     vim \
     gdb
+
+# Github CLI
+RUN (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt update \
+    && apt install gh -y
 
 # YCM
 ARG YCM_VERSION=v0.15.2
@@ -60,9 +85,9 @@ RUN cd $CODE_DIR && \
 EXPOSE 10000/tcp 10000/udp
 RUN yarp check
 
-# event-driven
 
-ARG ED_VERSION=master
+# event-driven
+ARG ED_VERSION=main
 RUN cd $CODE_DIR &&\
     git clone --depth 1 --branch $ED_VERSION https://github.com/robotology/event-driven.git &&\
     cd event-driven &&\

--- a/README.md
+++ b/README.md
@@ -72,3 +72,18 @@ Terminal 3 (on docker container)
 cd /usr/local/src/EDOPT/code/build
 ./edopt
 ```
+
+### For development from docker container
+Solution for Git Authentication
+
+Terminal 1 (on docker container)
+```
+gh auth login
+```
+- Then, select as shown below
+  - ? Where do you use GitHub? > GitHub.com
+  - ? What is your preferred protocol for Git operations on this host? > HTTPS
+  - ? How would you like to authenticate GitHub CLI? > Login with a web browser
+  - ! First copy your one-time code: XXXX-XXX
+  - Open this link [https://github.com/login/device](https://github.com/login/device)
+  - In the web browser, input one-time code to login

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Terminal 1 (on docker container)
 ```
 gh auth login
 ```
-- Then, select as shown below
+- Then, select as follows
   - ? Where do you use GitHub? > GitHub.com
   - ? What is your preferred protocol for Git operations on this host? > HTTPS
   - ? How would you like to authenticate GitHub CLI? > Login with a web browser

--- a/README.md
+++ b/README.md
@@ -70,5 +70,5 @@ atis-bridge-sdk --s 50
 Terminal 3 (on docker container)
 ```
 cd /usr/local/src/EDOPT/code/build
-./sixdofdev
+./edopt
 ```

--- a/README.md
+++ b/README.md
@@ -27,26 +27,32 @@ Three simultaneous computations:
 
 ```
 cd EDOPT
-eval $(ssh-agent -s)
-ssh-add path/to/your/ssh/secret/key
-docker build -t sixdof:latest --ssh default .
+docker build -t edopt:latest .
 
 ## if you want to build another remote branch for debugging ...
-docker build -t sixdof:latest --build-arg GIT_BRANCH=your/specified/remote/branch --ssh default  .
+docker build -t edopt:latest --build-arg GIT_BRANCH=your/specified/remote/branch .
 ```
 ### Make and enter the container using:
 
 ```
-docker run -it --privileged -v /dev/bus/usb:/dev/bus/usb -v /tmp/.X11-unix/:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY --network host --gpus all --name sixdofdev sixdof:latest
+docker run -it --privileged -v /dev/bus/usb:/dev/bus/usb -v /tmp/.X11-unix/:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY --network host --gpus all --name edopt edopt:latest
 ```
 or
 ```
 docker compose up -d
-docker exec -it edopt-sixdofdev-1 /bin/bash
+docker exec -it edopt /bin/bash
+```
+### How to build EDOPT
+Terminal 1 (on docker container)
+```
+mkdir -p /usr/local/src/EDOPT/code/build
+cd /usr/local/src/EDOPT/code/build
+cmake ..
+make
 ```
 
 ### How to run EDOPT
-Terminal 1 (on host)
+Terminal 1 (on docker container)
 ```
 yarpserver
 ```

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # produce the cmake var PROJECT_NAME
-project(sixdofobject)
+project(edopt)
 
 if(NOT CMAKE_BUILD_TYPE)
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
@@ -24,10 +24,10 @@ find_package(event-driven REQUIRED)
 #                          INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
 #                          USE_LINK_PATH)
 
-add_executable(sixdofobject main.cpp image_processing.h projection.h erosdirect.h comparison.h)
-target_compile_features(sixdofobject PRIVATE cxx_std_17)
+add_executable(${PROJECT_NAME} main.cpp image_processing.h projection.h erosdirect.h comparison.h)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 #target_compile_options(sixdofobject PRIVATE -Werror -Wall -Wextra)
-target_link_libraries(sixdofobject PRIVATE  YARP_init
+target_link_libraries(${PROJECT_NAME} PRIVATE  YARP_init
                                             YARP_os
                                             event-driven
                                             ${OpenCV_LIBS}
@@ -35,5 +35,5 @@ target_link_libraries(sixdofobject PRIVATE  YARP_init
                                             MetavisionSDK::driver
                                             SI::SuperimposeMesh)
 
-install(TARGETS sixdofobject DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
-version: '3'
 services:
-  sixdofdev:
-    image: sixdof:latest
+  edopt:
+    image: edopt:latest
+    container_name: edopt
     privileged: true
     volumes:
       - /dev/bus/usb:/dev/bus/usb


### PR DESCRIPTION
## Related issue
#10 

## Major modification
- Use `https` to clone EDOPT public repository during docker build
- Add explation about how to develop from docker container by using Github CLI authentication

## Minor modification
- Rename from sixdof to `edopt`
- Add suggested denendencies for YARP in Dockerfile